### PR TITLE
Remove API key prompting and use environment variables only

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,6 @@ WORKSPACE="${OPENCLAW_WORKSPACE:-$HOME/.openclaw/workspace-claude-code}"
 # Parse arguments
 VERIFY_ONLY=0
 FORCE_INSTALL=0
-NO_PROMPT=0
 DB_NAME_OVERRIDE=""
 
 while [[ $# -gt 0 ]]; do
@@ -27,10 +26,6 @@ while [[ $# -gt 0 ]]; do
             FORCE_INSTALL=1
             shift
             ;;
-        --no-prompt)
-            NO_PROMPT=1
-            shift
-            ;;
         --database|-d)
             DB_NAME_OVERRIDE="$2"
             shift 2
@@ -41,7 +36,6 @@ while [[ $# -gt 0 ]]; do
             echo "Options:"
             echo "  --verify-only         Check installation without modifying anything"
             echo "  --force               Force overwrite existing files (skip file verification)"
-            echo "  --no-prompt           Skip interactive prompts (for automated installs)"
             echo "  --database, -d NAME   Override database name (default: \${USER}_memory)"
             echo "  --help                Show this help message"
             echo ""
@@ -49,7 +43,6 @@ while [[ $# -gt 0 ]]; do
             echo "  $0                              # Use default database name"
             echo "  $0 --database nova_memory       # Use specific database"
             echo "  $0 -d nova_memory               # Short form"
-            echo "  $0 --no-prompt                  # Skip API key prompts"
             exit 0
             ;;
         *)
@@ -92,90 +85,6 @@ else
 fi
 echo "═══════════════════════════════════════════"
 echo ""
-
-# ============================================
-# API Key Setup Functions
-# ============================================
-
-# Determine shell profile file
-get_shell_profile() {
-    if [ -f "$HOME/.bashrc" ]; then
-        echo "$HOME/.bashrc"
-    elif [ -f "$HOME/.bash_profile" ]; then
-        echo "$HOME/.bash_profile"
-    elif [ -f "$HOME/.profile" ]; then
-        echo "$HOME/.profile"
-    else
-        # Default to .bashrc even if it doesn't exist yet
-        echo "$HOME/.bashrc"
-    fi
-}
-
-# Prompt for and save API key
-prompt_and_save_key() {
-    local var_name="$1"
-    local prompt_message="$2"
-    local feature_description="$3"
-    
-    # Skip if --no-prompt flag is set
-    if [ $NO_PROMPT -eq 1 ]; then
-        return 0
-    fi
-    
-    # Skip if already set
-    if [ -n "${!var_name}" ]; then
-        return 0
-    fi
-    
-    echo ""
-    echo -e "${YELLOW}${var_name} not set${NC}"
-    echo -n "$prompt_message"
-    
-    # Read API key (hide input if possible)
-    if [ -t 0 ]; then
-        read -s api_key
-        echo ""  # New line after hidden input
-    else
-        read api_key
-    fi
-    
-    # If user pressed Enter without input, skip
-    if [ -z "$api_key" ]; then
-        echo -e "  ${WARNING} Skipped - $feature_description won't work without this key"
-        return 0
-    fi
-    
-    # Validate key format (basic check)
-    if [[ ! "$api_key" =~ ^sk- ]]; then
-        echo -e "  ${WARNING} Key doesn't start with 'sk-', but saving anyway..."
-    fi
-    
-    # Get shell profile
-    SHELL_PROFILE=$(get_shell_profile)
-    
-    # Check if already in profile
-    if grep -q "export $var_name=" "$SHELL_PROFILE" 2>/dev/null; then
-        # Update existing line
-        if [[ "$OSTYPE" == "darwin"* ]]; then
-            # macOS sed requires empty string after -i
-            sed -i "" "s|export $var_name=.*|export $var_name=\"$api_key\"|" "$SHELL_PROFILE"
-        else
-            sed -i "s|export $var_name=.*|export $var_name=\"$api_key\"|" "$SHELL_PROFILE"
-        fi
-    else
-        # Add new line
-        echo "" >> "$SHELL_PROFILE"
-        echo "# Added by nova-memory installer" >> "$SHELL_PROFILE"
-        echo "export $var_name=\"$api_key\"" >> "$SHELL_PROFILE"
-    fi
-    
-    # Export for current session
-    export "$var_name=$api_key"
-    
-    echo -e "  ${CHECK_MARK} $var_name saved to $SHELL_PROFILE"
-    
-    return 0
-}
 
 # ============================================
 # Verification Functions
@@ -360,34 +269,37 @@ verify_config() {
     echo "Config verification..."
     
     # Check environment variables
-    local required_vars=("PGUSER" "ANTHROPIC_API_KEY")
-    local optional_vars=("OPENAI_API_KEY" "OPENCLAW_WORKSPACE")
+    # Note: Hooks run as child processes of OpenClaw and inherit its environment
+    # API keys should be configured in OpenClaw, not separately for nova-memory
     
-    for var in "${required_vars[@]}"; do
-        if [ -z "${!var}" ]; then
-            echo -e "  ${WARNING} $var not set"
-            VERIFICATION_WARNINGS=$((VERIFICATION_WARNINGS + 1))
-        else
-            # Don't print full value for API keys
-            if [[ "$var" == *"KEY"* ]]; then
-                echo -e "  ${CHECK_MARK} $var set: ${!var:0:8}..."
-            else
-                echo -e "  ${CHECK_MARK} $var set: ${!var}"
-            fi
-        fi
-    done
+    if [ -z "$PGUSER" ]; then
+        echo -e "  ${WARNING} PGUSER not set (using current user: $(whoami))"
+        VERIFICATION_WARNINGS=$((VERIFICATION_WARNINGS + 1))
+    else
+        echo -e "  ${CHECK_MARK} PGUSER set: $PGUSER"
+    fi
     
-    for var in "${optional_vars[@]}"; do
-        if [ -z "${!var}" ]; then
-            echo -e "  ${INFO} $var not set (optional)"
-        else
-            if [[ "$var" == *"KEY"* ]]; then
-                echo -e "  ${CHECK_MARK} $var set: ${!var:0:8}..."
-            else
-                echo -e "  ${CHECK_MARK} $var set: ${!var}"
-            fi
-        fi
-    done
+    if [ -z "$ANTHROPIC_API_KEY" ]; then
+        echo -e "  ${WARNING} ANTHROPIC_API_KEY not set in environment"
+        echo -e "      Hooks will inherit from OpenClaw's environment"
+        VERIFICATION_WARNINGS=$((VERIFICATION_WARNINGS + 1))
+    else
+        echo -e "  ${CHECK_MARK} ANTHROPIC_API_KEY set: ${ANTHROPIC_API_KEY:0:8}..."
+    fi
+    
+    if [ -z "$OPENAI_API_KEY" ]; then
+        echo -e "  ${WARNING} OPENAI_API_KEY not set in environment"
+        echo -e "      Hooks will inherit from OpenClaw's environment"
+        VERIFICATION_WARNINGS=$((VERIFICATION_WARNINGS + 1))
+    else
+        echo -e "  ${CHECK_MARK} OPENAI_API_KEY set: ${OPENAI_API_KEY:0:8}..."
+    fi
+    
+    if [ -z "$OPENCLAW_WORKSPACE" ]; then
+        echo -e "  ${INFO} OPENCLAW_WORKSPACE not set (using default: $WORKSPACE)"
+    else
+        echo -e "  ${CHECK_MARK} OPENCLAW_WORKSPACE set: $OPENCLAW_WORKSPACE"
+    fi
     
     # Check database connection
     if psql -U "$DB_USER" -d "$DB_NAME" -c '\q' 2>/dev/null; then
@@ -495,37 +407,6 @@ if [ $VERIFY_ONLY -eq 1 ]; then
         echo -e "  ${CHECK_MARK} All checks passed"
         exit 0
     fi
-fi
-
-# ============================================
-# Part 1.5: API Key Configuration
-# ============================================
-echo ""
-echo "Config setup..."
-
-# Prompt for OpenAI API key (required for semantic-recall hook)
-prompt_and_save_key \
-    "OPENAI_API_KEY" \
-    "Enter your OpenAI API key (required for semantic recall) [or press Enter to skip]: " \
-    "semantic recall"
-
-# Prompt for Anthropic API key (required for memory-extract hook)
-prompt_and_save_key \
-    "ANTHROPIC_API_KEY" \
-    "Enter your Anthropic API key (required for memory extraction) [or press Enter to skip]: " \
-    "memory extraction"
-
-# Check current status
-if [ -n "$OPENAI_API_KEY" ]; then
-    echo -e "  ${CHECK_MARK} OPENAI_API_KEY configured"
-else
-    echo -e "  ${WARNING} OPENAI_API_KEY not set (semantic recall won't work)"
-fi
-
-if [ -n "$ANTHROPIC_API_KEY" ]; then
-    echo -e "  ${CHECK_MARK} ANTHROPIC_API_KEY configured"
-else
-    echo -e "  ${WARNING} ANTHROPIC_API_KEY not set (memory extraction won't work)"
 fi
 
 # ============================================

--- a/scripts/embed-delegation-facts.sh
+++ b/scripts/embed-delegation-facts.sh
@@ -12,19 +12,10 @@ DB_USER="${PGUSER:-$(whoami)}"
 DB_NAME="${DB_USER//-/_}_memory"
 DB_HOST="localhost"
 
-# OpenAI API key
-OPENAI_API_KEY="${OPENAI_API_KEY:-}"
+# API key must be set in environment (inherited from OpenClaw)
 if [ -z "$OPENAI_API_KEY" ]; then
-    if [ -f ~/.secrets/openai-api-key ]; then
-        OPENAI_API_KEY=$(cat ~/.secrets/openai-api-key)
-    elif [ -f ~/.openclaw/openclaw.json ]; then
-        OPENAI_API_KEY=$(jq -r '.skills.entries."openai-image-gen".apiKey // empty' ~/.openclaw/openclaw.json 2>/dev/null)
-    fi
-fi
-
-if [ -z "$OPENAI_API_KEY" ]; then
-    echo "ERROR: OPENAI_API_KEY not found"
-    echo "Set it in environment or ~/.secrets/openai-api-key"
+    echo "ERROR: OPENAI_API_KEY not set in environment" >&2
+    echo "This script should be run from OpenClaw hooks which inherit the API key" >&2
     exit 1
 fi
 

--- a/scripts/extract-memories.sh
+++ b/scripts/extract-memories.sh
@@ -9,8 +9,12 @@ SENDER="${SENDER_NAME:-unknown}"
 SENDER_ID="${SENDER_ID:-}"
 IS_GROUP="${IS_GROUP:-false}"
 
-[ -z "$ANTHROPIC_API_KEY" ] && [ -f ~/.secrets/anthropic-api-key ] && ANTHROPIC_API_KEY=$(cat ~/.secrets/anthropic-api-key)
-[ -z "$ANTHROPIC_API_KEY" ] && exit 1
+# API key must be set in environment (inherited from OpenClaw)
+if [ -z "$ANTHROPIC_API_KEY" ]; then
+    echo "ERROR: ANTHROPIC_API_KEY not set in environment" >&2
+    echo "This script should be run from OpenClaw hooks which inherit the API key" >&2
+    exit 1
+fi
 
 # Database configuration - use dynamic naming based on OS user
 DB_USER="${PGUSER:-$(whoami)}"

--- a/scripts/memory-catchup.sh
+++ b/scripts/memory-catchup.sh
@@ -197,8 +197,12 @@ while IFS= read -r line; do
         # SENDER_ID should come from the hook for user messages
     fi
     
-    # Run extraction
-    export ANTHROPIC_API_KEY="${ANTHROPIC_API_KEY:-$(grep ANTHROPIC_API_KEY ~/.bashrc | cut -d= -f2 | tr -d \"\'\" | head -1)}"
+    # Run extraction (API key must be in environment, inherited from OpenClaw)
+    if [ -z "$ANTHROPIC_API_KEY" ]; then
+        echo "ERROR: ANTHROPIC_API_KEY not set in environment" >&2
+        echo "This script should be run from OpenClaw hooks which inherit the API key" >&2
+        exit 1
+    fi
     
     if [ "$VERBOSE_LOG" = true ]; then
         EXTRACT_LOG="${HOME}/.openclaw/logs/memory-extractions.log"

--- a/scripts/proactive-recall.py
+++ b/scripts/proactive-recall.py
@@ -54,16 +54,15 @@ CONTENT_LIMITS = {
 }
 
 def get_openai_client():
-    """Get OpenAI client with API key."""
+    """Get OpenAI client with API key from environment.
+    
+    API key must be set in environment (inherited from OpenClaw).
+    """
     api_key = os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        config_path = Path.home() / ".openclaw" / "openclaw.json"
-        if config_path.exists():
-            with open(config_path) as f:
-                config = json.load(f)
-                api_key = config.get("skills", {}).get("entries", {}).get("openai-image-gen", {}).get("apiKey")
     
     if not api_key:
+        print("ERROR: OPENAI_API_KEY not set in environment", file=sys.stderr)
+        print("This script should be run from OpenClaw hooks which inherit the API key", file=sys.stderr)
         return None
     
     return openai.OpenAI(api_key=api_key)

--- a/scripts/test-delegation-memory.sh
+++ b/scripts/test-delegation-memory.sh
@@ -52,17 +52,9 @@ echo ""
 if [ -f ~/clawd/nova-memory/scripts/proactive-recall.py ]; then
     echo "📊 Test 4: Semantic search for delegation"
     
-    OPENAI_API_KEY="${OPENAI_API_KEY:-}"
     if [ -z "$OPENAI_API_KEY" ]; then
-        if [ -f ~/.secrets/openai-api-key ]; then
-            OPENAI_API_KEY=$(cat ~/.secrets/openai-api-key)
-        elif [ -f ~/.openclaw/openclaw.json ]; then
-            OPENAI_API_KEY=$(jq -r '.skills.entries."openai-image-gen".apiKey // empty' ~/.openclaw/openclaw.json 2>/dev/null)
-        fi
-    fi
-    
-    if [ -z "$OPENAI_API_KEY" ]; then
-        echo "   ⚠️  OPENAI_API_KEY not found, skipping semantic search test"
+        echo "   ⚠️  OPENAI_API_KEY not set in environment, skipping semantic search test"
+        echo "      Set OPENAI_API_KEY environment variable to run this test"
     else
         export OPENAI_API_KEY
         echo "   Query: 'help me debug this Python code'"


### PR DESCRIPTION
## Summary

Removes API key prompting from the installer and ensures all scripts use environment variables exclusively.

## Rationale

Hooks run as child processes of OpenClaw and inherit its environment, which already contains the API keys. No need to prompt users or store keys separately. The agent wouldn't be running if keys weren't already configured in OpenClaw.

## Changes

### install.sh
- ✂️ Removed `prompt_and_save_key()` and `get_shell_profile()` functions
- ✂️ Removed `--no-prompt` flag (no longer needed)
- ✂️ Removed 'Config setup' section that prompted for API keys
- ✏️ Updated `verify_config()` to just warn if keys not in environment

### Scripts (all .sh and .py in scripts/)
- ✂️ Removed fallback logic that reads from `~/.secrets/` files
- ✂️ Removed fallback logic that reads from `~/.bashrc`
- ✂️ Removed fallback logic that reads from `~/.openclaw/openclaw.json`
- ✏️ Scripts now fail with clear error message if API keys not in environment

## Files Modified

- `install.sh`
- `scripts/embed-delegation-facts.sh`
- `scripts/extract-memories.sh`
- `scripts/memory-catchup.sh`
- `scripts/proactive-recall.py`
- `scripts/test-delegation-memory.sh`

## Expected Behavior After Merge

- ✅ Installer warns if API keys not in environment at install time
- ✅ Scripts expect API keys from environment (inherited from OpenClaw)
- ✅ Scripts exit with clear error message if API keys not set
- ✅ No prompting, no file-based key storage

## Testing

- ✅ `bash -n install.sh` passes (syntax check)
- ✅ All modified scripts reviewed for fallback logic
- ✅ All API key access now uses `$ANTHROPIC_API_KEY` and `$OPENAI_API_KEY` from environment only
- ✅ No remaining references to `~/.secrets/`, `~/.bashrc`, or config file fallbacks