### PR TITLE
fix: use OPENCLAW_WORKSPACE env var for hook paths (closes #29)

### DIFF
--- a/hooks/semantic-recall/handler.ts
+++ b/hooks/semantic-recall/handler.ts
@@ -14,7 +14,8 @@ import {
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const RECALL_SCRIPT = join(__dirname, '../../scripts/proactive-recall.py');
-const PYTHON_VENV = join(os.homedir(), "clawd/scripts/tts-venv/bin/python");
+const WORKSPACE = process.env.OPENCLAW_WORKSPACE || join(process.env.HOME || os.homedir(), '.openclaw');
+const PYTHON_VENV = join(WORKSPACE, 'scripts/tts-venv/bin/python');
 
 // Configurable via environment variables
 const TOKEN_BUDGET = parseInt(process.env.SEMANTIC_RECALL_TOKEN_BUDGET || "1000", 10);

--- a/hooks/session-init/handler.ts
+++ b/hooks/session-init/handler.ts
@@ -4,7 +4,8 @@ import { fileURLToPath } from "url";
 import { dirname, join } from "path";
 import * as os from "os";
 
-const CONTEXT_FILE = join(os.homedir(), "clawd/SESSION_CONTEXT.md");
+const WORKSPACE = process.env.OPENCLAW_WORKSPACE || join(process.env.HOME || os.homedir(), '.openclaw');
+const CONTEXT_FILE = join(WORKSPACE, 'SESSION_CONTEXT.md');
 const STALE_MINUTES = 5;
 
 // Track current session participants


### PR DESCRIPTION
This PR fixes hardcoded paths in the hook handlers to use the OPENCLAW_WORKSPACE environment variable with a fallback to $HOME/.openclaw.

Changes:
- hooks/semantic-recall/handler.ts - fixed hardcoded Python path  
- hooks/session-init/handler.ts - fixed hardcoded context file path

Both handlers now use $OPENCLAW_WORKSPACE with $HOME/.openclaw fallback for better portability.

Closes #29