### PR TITLE
Rename agent references: nhr-agent→newhart, claude-code→coder

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -291,9 +291,9 @@ The new `install.sh` copies hooks instead, which is more reliable.
 If you previously used symlinks, remove them first:
 
 ```bash
-rm -rf ~/.openclaw/workspace-claude-code/hooks/memory-extract
-rm -rf ~/.openclaw/workspace-claude-code/hooks/semantic-recall
-rm -rf ~/.openclaw/workspace-claude-code/hooks/session-init
+rm -rf ~/.openclaw/workspace-coder/hooks/memory-extract
+rm -rf ~/.openclaw/workspace-coder/hooks/semantic-recall
+rm -rf ~/.openclaw/workspace-coder/hooks/session-init
 ```
 
 Then run the new installer:
@@ -420,7 +420,7 @@ nova-memory/
 
 ### After Installation (Workspace)
 ```
-~/.openclaw/workspace-claude-code/
+~/.openclaw/workspace-coder/
 ├── hooks/                  # Installed hooks
 │   ├── memory-extract/     # → Uses ../../scripts/process-input.sh
 │   ├── semantic-recall/    # → Uses ../../scripts/proactive-recall.py

--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Agents can now be mentioned using any of their identifiers, matched case-insensi
 - **Config agentName** (from Clawdbot config)
 
 **Benefits:**
-- `@nhr-agent`, `@NHR-AGENT`, `@Nhr-Agent` all work
+- `@newhart`, `@NEWHART`, `@Newhart` all work
 - `@Newhart` matches if "Newhart" is the nickname
 - `@bob` matches if "bob" is an alias
 
@@ -412,34 +412,34 @@ Agents can now send messages using human-friendly identifiers instead of exact d
 **Enhanced sendText() Function:**
 ```typescript
 // Old way: Need exact database name
-sendText({ to: "nhr-agent", text: "Hello" })
+sendText({ to: "newhart", text: "Hello" })
 
 // New way: Use friendly identifiers  
 sendText({ to: "Newhart", text: "Hello" })     // nickname
 sendText({ to: "bob", text: "Hello" })         // alias
-sendText({ to: "NHR-AGENT", text: "Hello" })  // case-insensitive name
+sendText({ to: "NEWHART", text: "Hello" })  // case-insensitive name
 ```
 
 **Examples:**
 
 ```sql
 -- Setup: Agent with multiple identifiers
-INSERT INTO agents (name, nickname) VALUES ('nhr-agent', 'Newhart');
+INSERT INTO agents (name, nickname) VALUES ('newhart', 'Newhart');
 INSERT INTO agent_aliases (agent_id, alias) 
-SELECT id, 'bob' FROM agents WHERE name = 'nhr-agent';
+SELECT id, 'bob' FROM agents WHERE name = 'newhart';
 
 -- All these resolve to the same agent:
-SELECT resolveAgentName('nhr-agent');  -- → 'nhr-agent'
-SELECT resolveAgentName('Newhart');    -- → 'nhr-agent'  
-SELECT resolveAgentName('BOB');        -- → 'nhr-agent'
+SELECT resolveAgentName('newhart');  -- → 'newhart'
+SELECT resolveAgentName('Newhart');    -- → 'newhart'  
+SELECT resolveAgentName('BOB');        -- → 'newhart'
 ```
 
 **Full Workflow:**
 1. **Send:** `sendText({ to: "Newhart", text: "Hello" })`
-2. **Resolve:** "Newhart" → resolves to "nhr-agent" 
-3. **Route:** Message stored with `mentions: ["nhr-agent"]`
-4. **Receive:** nhr-agent's identifiers include "newhart" → message matches
-5. **Deliver:** Message delivered to nhr-agent session
+2. **Resolve:** "Newhart" → resolves to "newhart" 
+3. **Route:** Message stored with `mentions: ["newhart"]`
+4. **Receive:** newhart's identifiers include "newhart" → message matches
+5. **Deliver:** Message delivered to newhart session
 
 **Backward Compatibility:** All existing code continues to work unchanged.
 
@@ -776,7 +776,7 @@ Run the installation script to symlink hooks to your OpenClaw workspace:
 ./install-hooks.sh
 ```
 
-This creates symlinks from `~/.openclaw/workspace-claude-code/hooks/` to `nova-memory/hooks/`. Symlinks ensure:
+This creates symlinks from `~/.openclaw/workspace-coder/hooks/` to `nova-memory/hooks/`. Symlinks ensure:
 - Hooks stay under version control
 - Changes are tracked in git
 - Updates propagate automatically
@@ -814,7 +814,7 @@ Memories are automatically extracted and stored from conversations.
 To remove hooks:
 
 ```bash
-cd ~/.openclaw/workspace-claude-code/hooks/
+cd ~/.openclaw/workspace-coder/hooks/
 rm memory-extract semantic-recall session-init
 ```
 

--- a/tests/TEST-CASES-ISSUE-70.md
+++ b/tests/TEST-CASES-ISSUE-70.md
@@ -10,20 +10,20 @@
 
 **ID:** TC-70-001  
 **Priority:** High  
-**Prerequisite:** Agent "nhr-agent" exists with nickname "Newhart" in agent registry
+**Prerequisite:** Agent "newhart" exists with nickname "Newhart" in agent registry
 
 **Given:** 
 - The agent_chat plugin is initialized
-- Agent registry contains entry: `{agentName: "nhr-agent", nickname: "Newhart"}`
+- Agent registry contains entry: `{agentName: "newhart", nickname: "Newhart"}`
 - Current agent config has sender name configured
 
 **When:** 
 - User calls send tool with target "Newhart" and message "Hello from test"
 
 **Then:**
-- Target is resolved to agentName "nhr-agent"
+- Target is resolved to agentName "newhart"
 - Message is inserted into agent_chat table with:
-  - `mentions` array contains "nhr-agent"
+  - `mentions` array contains "newhart"
   - `sender` field contains current agent's name
   - `message` field contains "Hello from test"
 - Success confirmation is returned
@@ -35,21 +35,21 @@
 
 **ID:** TC-70-002  
 **Priority:** High  
-**Prerequisite:** Agent "nhr-agent" exists with database name "newhart"
+**Prerequisite:** Agent "newhart" exists with database name "newhart"
 
 **Given:**
 - The agent_chat plugin is initialized
-- Agent registry contains entry: `{agentName: "nhr-agent", dbName: "newhart"}`
+- Agent registry contains entry: `{agentName: "newhart", dbName: "newhart"}`
 - Current agent is authenticated
 
 **When:**
 - User calls send tool with target "newhart" and message "Testing db name"
 
 **Then:**
-- Target is resolved to agentName "nhr-agent"
+- Target is resolved to agentName "newhart"
 - Message is inserted successfully with proper mentions array
 - Lookup uses #69 infrastructure for name resolution
-- Response confirms delivery to "nhr-agent"
+- Response confirms delivery to "newhart"
 
 ---
 
@@ -57,18 +57,18 @@
 
 **ID:** TC-70-003  
 **Priority:** High  
-**Prerequisite:** Agent "nhr-agent" exists in registry
+**Prerequisite:** Agent "newhart" exists in registry
 
 **Given:**
 - The agent_chat plugin is initialized
-- Agent "nhr-agent" exists in agent registry
+- Agent "newhart" exists in agent registry
 
 **When:**
-- User calls send tool with target "nhr-agent" and message "Direct agentName test"
+- User calls send tool with target "newhart" and message "Direct agentName test"
 
 **Then:**
 - Target matches agentName directly (no lookup required)
-- Message is inserted with mentions=["nhr-agent"]
+- Message is inserted with mentions=["newhart"]
 - No additional resolution steps are performed
 - Success response is returned immediately
 
@@ -81,14 +81,14 @@
 **Prerequisite:** Agent has configured alias
 
 **Given:**
-- Agent registry contains: `{agentName: "nhr-agent", alias: "bob"}`
+- Agent registry contains: `{agentName: "newhart", alias: "bob"}`
 - Current agent has send permissions
 
 **When:**
 - User calls send tool with target "bob" and message "Alias test"
 
 **Then:**
-- Alias "bob" is resolved to agentName "nhr-agent"
+- Alias "bob" is resolved to agentName "newhart"
 - Message is inserted with correct mentions array
 - Lookup checks alias field in registry
 - Confirmation indicates delivery to resolved agent
@@ -99,7 +99,7 @@
 
 **ID:** TC-70-005  
 **Priority:** High  
-**Prerequisite:** Agent "nhr-agent" with nickname "Newhart" exists
+**Prerequisite:** Agent "newhart" with nickname "Newhart" exists
 
 **Given:**
 - Agent registry contains case-sensitive identifiers
@@ -110,10 +110,9 @@
   - "NEWHART" (all caps)
   - "newhart" (all lowercase)
   - "NewHart" (mixed case)
-  - "NHR-AGENT" (agentName caps)
 
 **Then:**
-- All variations resolve to agentName "nhr-agent"
+- All variations resolve to agentName "newhart"
 - Case-insensitive matching is applied to:
   - nickname
   - dbName
@@ -154,7 +153,7 @@
 
 **Given:**
 - Current agent config: `{agentName: "erato", displayName: "Erato"}`
-- Target agent "nhr-agent" exists and is valid
+- Target agent "newhart" exists and is valid
 
 **When:**
 - Agent sends message using send tool
@@ -174,7 +173,7 @@
 **Prerequisite:** Valid target agent exists
 
 **Given:**
-- Target agent "nhr-agent" is valid and active
+- Target agent "newhart" is valid and active
 - Message content is non-empty
 
 **When:**
@@ -185,7 +184,7 @@
   - Target agent name (resolved)
   - Message ID or timestamp
   - Success status
-- Example: "Message sent to nhr-agent (Newhart) at 2026-02-13T10:59:00Z"
+- Example: "Message sent to newhart (Newhart) at 2026-02-13T10:59:00Z"
 - Confirmation is returned to caller immediately after INSERT
 
 ---
@@ -202,13 +201,13 @@
 
 **When:**
 - Send tool is called with:
-  - target: "nhr-agent"
+  - target: "newhart"
   - message: "This is a reply"
   - replyTo: "msg-123" (optional parameter)
 
 **Then:**
 - New message is inserted with:
-  - mentions=["nhr-agent"]
+  - mentions=["newhart"]
   - replyTo or threadId field = "msg-123"
 - Thread relationship is preserved
 - Target agent can reconstruct conversation thread
@@ -223,7 +222,7 @@
 **Prerequisite:** Multiple agents exist
 
 **Given:**
-- Registry contains "nhr-agent" and "erato"
+- Registry contains "newhart" and "erato"
 - Send tool accepts single target parameter
 
 **When:**
@@ -245,7 +244,7 @@
 **Prerequisite:** Valid target exists
 
 **Given:**
-- Target "nhr-agent" is valid
+- Target "newhart" is valid
 
 **When:**
 - Send tool is called with:

--- a/tests/TEST-CASES-ISSUE-76.md
+++ b/tests/TEST-CASES-ISSUE-76.md
@@ -27,19 +27,19 @@ The function should:
 **Priority:** Critical
 
 **Given:** 
-- Agent exists in database with name "nhr-agent"
+- Agent exists in database with name "newhart"
 
 **When:** 
-- `resolveAgentName(client, "nhr-agent")` is called
+- `resolveAgentName(client, "newhart")` is called
 
 **Then:**
-- Returns "nhr-agent"
+- Returns "newhart"
 - No error is thrown
 
 **Variations:**
-- "nhr-agent" → "nhr-agent" ✓
-- "NHR-AGENT" → "nhr-agent" ✓ (case-insensitive)
-- "Nhr-Agent" → "nhr-agent" ✓ (case-insensitive)
+- "newhart" → "newhart" ✓
+- "NEWHART" → "newhart" ✓ (case-insensitive)
+- "Newhart" → "newhart" ✓ (case-insensitive)
 
 ---
 
@@ -50,20 +50,20 @@ The function should:
 
 **Given:**
 - Agent exists with:
-  - `name`: "nhr-agent"
+  - `name`: "newhart"
   - `nickname`: "Newhart"
 
 **When:**
 - `resolveAgentName(client, "Newhart")` is called
 
 **Then:**
-- Returns "nhr-agent" (the canonical name)
+- Returns "newhart" (the canonical name)
 - Nickname matching is case-insensitive
 
 **Variations:**
-- "Newhart" → "nhr-agent" ✓
-- "newhart" → "nhr-agent" ✓
-- "NEWHART" → "nhr-agent" ✓
+- "Newhart" → "newhart" ✓
+- "newhart" → "newhart" ✓
+- "NEWHART" → "newhart" ✓
 
 ---
 
@@ -73,7 +73,7 @@ The function should:
 **Priority:** High
 
 **Given:**
-- Agent "nhr-agent" has aliases:
+- Agent "newhart" has aliases:
   - "bob" (from agent_aliases table)
   - "newhart-bot" (from agent_aliases table)
 
@@ -81,14 +81,14 @@ The function should:
 - `resolveAgentName(client, "bob")` is called
 
 **Then:**
-- Returns "nhr-agent"
+- Returns "newhart"
 - Alias matching is case-insensitive
 
 **Variations:**
-- "bob" → "nhr-agent" ✓
-- "BOB" → "nhr-agent" ✓
-- "newhart-bot" → "nhr-agent" ✓
-- "NEWHART-BOT" → "nhr-agent" ✓
+- "bob" → "newhart" ✓
+- "BOB" → "newhart" ✓
+- "newhart-bot" → "newhart" ✓
+- "NEWHART-BOT" → "newhart" ✓
 
 ---
 
@@ -200,10 +200,10 @@ LIMIT 1;
 ### Test with Various Inputs
 ```typescript
 // Test cases to run
-await resolveAgentName(client, "nhr-agent");    // Should return "nhr-agent"
-await resolveAgentName(client, "Newhart");      // Should return "nhr-agent"
-await resolveAgentName(client, "NEWHART");      // Should return "nhr-agent"
-await resolveAgentName(client, "bob");          // Should return "nhr-agent" (if alias exists)
+await resolveAgentName(client, "newhart");    // Should return "newhart"
+await resolveAgentName(client, "Newhart");      // Should return "newhart"
+await resolveAgentName(client, "NEWHART");      // Should return "newhart"
+await resolveAgentName(client, "bob");          // Should return "newhart" (if alias exists)
 await resolveAgentName(client, "nonexistent");  // Should throw error
 await resolveAgentName(client, "");             // Should throw "Target cannot be empty"
 ```


### PR DESCRIPTION
Standardize all agent name references to lowercase nicknames per the new naming convention.

Files updated:
- INSTALLATION.md: workspace-claude-code → workspace-coder
- README.md: nhr-agent → newhart, claude-code → coder
- tests/TEST-CASES-ISSUE-70.md: nhr-agent → newhart
- tests/TEST-CASES-ISSUE-76.md: nhr-agent → newhart

Closes #90