### PR TITLE
fix: correct Anthropic API key warning messages in shell-install.sh

### DIFF
--- a/shell-install.sh
+++ b/shell-install.sh
@@ -155,7 +155,7 @@ fi
 ANTHROPIC_KEY=$(jq -r '.env.vars.ANTHROPIC_API_KEY // empty' "$OPENCLAW_CONFIG" 2>/dev/null)
 if [ -z "$ANTHROPIC_KEY" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
     echo -e "  ${YELLOW}⚠️  ANTHROPIC_API_KEY not found${NC}"
-    echo "      Required for memory extraction (LLM calls)."
+    echo "      Used by OpenClaw as the primary LLM provider."
     echo "      Get a key from: https://console.anthropic.com/settings/keys"
     echo ""
     read -rp "    Enter your Anthropic API key (or press Enter to skip): " INPUT_ANTHROPIC_KEY
@@ -167,7 +167,7 @@ if [ -z "$ANTHROPIC_KEY" ] && [ -z "${ANTHROPIC_API_KEY:-}" ]; then
         export ANTHROPIC_API_KEY="$INPUT_ANTHROPIC_KEY"
         echo -e "  ${GREEN}✅${NC} ANTHROPIC_API_KEY written to $OPENCLAW_CONFIG"
     else
-        echo -e "  ${YELLOW}⚠️  Skipped — memory extraction will not work without ANTHROPIC_API_KEY${NC}"
+        echo -e "  ${YELLOW}⚠️  Skipped — some hooks and LLM features may not work without ANTHROPIC_API_KEY${NC}"
     fi
 elif [ -n "$ANTHROPIC_KEY" ]; then
     export ANTHROPIC_API_KEY="$ANTHROPIC_KEY"


### PR DESCRIPTION
Fixes the Anthropic API key warning messages in shell-install.sh to reference the correct key name.

Closes #113