### PR TITLE
feat(#139): add edition/version support to library_works

### DIFF
--- a/patches/add-library-editions.sql
+++ b/patches/add-library-editions.sql
@@ -1,0 +1,22 @@
+-- Patch: Add edition/version support to library_works
+-- Issue: NOVA-Openclaw/nova-memory#139
+--
+-- Adds:
+-- 1. edition column (nullable text) for edition/version identifier
+-- 2. embed column (boolean, default true) to control semantic embedding
+--
+-- Existing works are unaffected: edition=NULL, embed=true
+
+BEGIN;
+
+-- Add edition column (nullable — only set for works with editions)
+ALTER TABLE library_works ADD COLUMN IF NOT EXISTS edition TEXT;
+
+-- Add embed column (controls whether work is embedded for semantic recall)
+-- Default true so existing works continue to be embedded
+ALTER TABLE library_works ADD COLUMN IF NOT EXISTS embed BOOLEAN NOT NULL DEFAULT true;
+
+-- Add index for embed filtering (used by embed-library.py)
+CREATE INDEX IF NOT EXISTS idx_library_works_embed ON library_works (embed) WHERE embed = true;
+
+COMMIT;

--- a/schema.sql
+++ b/schema.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict ybRFBw3SoaSb5oH8lYDCUI3y7gaxajMatrUin1bblqjIhT2UuNhtbomYOCJkMvc
+\restrict EHEiI5NohZuGYjomVTZ1ZIqbiYIo10KrD8W0DU9ZmBdxgH8047oIpxkFLwvC1O0
 
 -- Dumped from database version 16.11 (Ubuntu 16.11-0ubuntu0.24.04.1)
 -- Dumped by pg_dump version 16.11 (Ubuntu 16.11-0ubuntu0.24.04.1)
@@ -3758,6 +3758,8 @@ CREATE TABLE public.library_works (
     search_vector tsvector,
     extra_metadata jsonb DEFAULT '{}'::jsonb,
     notable_quotes text[],
+    edition text,
+    embed boolean DEFAULT true NOT NULL,
     CONSTRAINT insights_not_empty CHECK ((length(TRIM(BOTH FROM insights)) > 20)),
     CONSTRAINT summary_not_empty CHECK ((length(TRIM(BOTH FROM summary)) > 50)),
     CONSTRAINT valid_work_type CHECK ((work_type = ANY (ARRAY['paper'::text, 'book'::text, 'novel'::text, 'poem'::text, 'short_story'::text, 'essay'::text, 'article'::text, 'blog_post'::text, 'whitepaper'::text, 'report'::text, 'thesis'::text, 'dissertation'::text, 'magazine'::text, 'newsletter'::text, 'speech'::text, 'other'::text])))
@@ -7701,6 +7703,13 @@ CREATE INDEX idx_library_works_doi ON public.library_works USING btree (doi) WHE
 
 
 --
+-- Name: idx_library_works_embed; Type: INDEX; Schema: public; Owner: nova
+--
+
+CREATE INDEX idx_library_works_embed ON public.library_works USING btree (embed) WHERE (embed = true);
+
+
+--
 -- Name: idx_library_works_isbn; Type: INDEX; Schema: public; Owner: nova
 --
 
@@ -10577,5 +10586,5 @@ ALTER EVENT TRIGGER schema_change_trigger OWNER TO postgres;
 -- PostgreSQL database dump complete
 --
 
-\unrestrict ybRFBw3SoaSb5oH8lYDCUI3y7gaxajMatrUin1bblqjIhT2UuNhtbomYOCJkMvc
+\unrestrict EHEiI5NohZuGYjomVTZ1ZIqbiYIo10KrD8W0DU9ZmBdxgH8047oIpxkFLwvC1O0
 

--- a/scripts/embed-library.py
+++ b/scripts/embed-library.py
@@ -26,7 +26,9 @@ SOURCE_TYPE = "library"
 
 LIBRARY_QUERY = """
     SELECT w.id,
-        w.title || ' by ' ||
+        w.title ||
+        COALESCE(' (' || w.edition || ')', '') ||
+        ' by ' ||
         COALESCE((
             SELECT string_agg(a.name, ', ' ORDER BY wa.author_order)
             FROM library_authors a
@@ -37,6 +39,7 @@ LIBRARY_QUERY = """
         w.summary ||
         COALESCE(' Notable quotes: ' || array_to_string(w.notable_quotes, ' | '), '')
     FROM library_works w
+    WHERE w.embed = true
 """
 
 


### PR DESCRIPTION
## Summary

Adds edition/version support to the library schema for works with multiple editions (D&D game books, textbooks, revised editions).

## Changes

- `patches/add-library-editions.sql` — adds `edition` (nullable text) and `embed` (boolean, default true) columns
- `scripts/embed-library.py` — filters on `embed = true`, includes edition in embedding text
- `schema.sql` — updated with new columns

## Design

- Each edition is a separate `library_works` record
- Only the latest edition has `embed = true` (appears in semantic search)
- Superseded editions have `embed = false` (stored for reference, not embedded)
- Edition lineage tracked via `library_work_relationships` with `supersedes` relation type
- Backward compatible: existing works get `edition = NULL`, `embed = true`

## Testing

- ✅ TC-1: edition column exists, nullable
- ✅ TC-2: embed column exists, NOT NULL, defaults true
- ✅ TC-3: embed-library.py has WHERE embed = true
- ✅ TC-4: 73 existing works unaffected (all embed=true, edition=NULL)
- ✅ TC-5: Work with embed=false excluded from embedding query
- ✅ TC-6: supersedes relationship type works in library_work_relationships

Closes #139