### PR TITLE
fix(#146): add header preamble to agent-turn-context injection

### DIFF
--- a/hooks/agent-turn-context/handler.ts
+++ b/hooks/agent-turn-context/handler.ts
@@ -99,7 +99,7 @@ const handler = async (event: any) => {
     const ctx = await getTurnContext(agentName);
 
     if (ctx.content) {
-      let injected = ctx.content;
+      let injected = '📌 **Per-Turn Reminders:**\n' + ctx.content;
 
       if (ctx.truncated) {
         console.warn(


### PR DESCRIPTION
Adds `📌 **Per-Turn Reminders:**` header before injected turn context, matching the pattern used by semantic-recall and entity context hooks. One-line change. `Closes #146`