### PR TITLE
feat: include library tags in semantic embedding text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 ### Added
 - **`agent_turn_context` table and per-turn injection hook** (#143) — New table stores short critical-context records (≤500 chars each) injected before every agent response. `get_agent_turn_context(agent_name)` aggregates context in priority order (UNIVERSAL → GLOBAL → DOMAIN → AGENT) up to a 2000-character budget with truncation warning. The new `agent-turn-context` hook fires on `message:received`, queries the table, and injects results into the agent's turn context with a 5-minute cache TTL per agent. Migration: `migrations/065_agent_turn_context.sql`.
 - **Library domain schema** — New tables for storing written works (research papers, books, novels, poems, essays, articles, etc.) with normalized authors, flexible tagging, and work-to-work relationships. Database constraints enforce complete ingestion (summary, insights, and all core metadata are required). See `docs/library-schema.md` and `patches/add-library-schema.sql`.
-- **Library semantic embedding** — Added `library` source type to `embed-full-database.py`. Embeds concise summaries (not full text) for high-density semantic search. Full records are fetched on recall hit.
+- **Library semantic embedding** — Added `library` source type to `embed-full-database.py`. Embeds title, authors, summary, notable quotes, and tags for high-density semantic search. Full records are fetched on recall hit.
 - **embed-full-database.py** — Added full database embedding script covering all source types (entities, facts, tasks, projects, agents, lessons, events, positions, media, vocabulary, library works).
 
 ### Fixed

--- a/docs/database-schema-guide.md
+++ b/docs/database-schema-guide.md
@@ -432,7 +432,7 @@ CREATE TABLE library_works (
 
 **Key design patterns:**
 - **NOT NULL constraints enforce completeness** — the database rejects records without summary, insights, publication_date, etc.
-- **summary field is used for semantic embedding** — one high-density embedding per work instead of chunking full text
+- **rich embedding per work** — one high-density embedding combining title, authors, summary, notable quotes, and tags; on recall hit the full record is fetched
 - **edition field** — nullable; identifies specific editions (e.g., "5th Edition", "2nd Edition")
 - **embed flag** — controls whether a work is included in semantic embedding; defaults to `true`
 - **Unique index** on `(LOWER(title), COALESCE(edition, ''))` — prevents duplicate records (same title+edition)

--- a/docs/library-schema.md
+++ b/docs/library-schema.md
@@ -7,7 +7,7 @@ A structured storage system for written works — research papers, books, novels
 The library stores all kinds of written works in a normalized schema with:
 
 - **Required metadata** — Database constraints enforce complete records (title, summary, insights, etc.)
-- **Semantic embedding** — Concise summaries are embedded for meaning-based recall
+- **Semantic embedding** — Title, authors, summary, notable quotes, and tags are combined into a single embedding per work for meaning-based recall
 - **Full-text search** — Weighted tsvector index for keyword queries
 - **Normalized authors** — Deduplicated author records linked via junction table
 - **Tagging system** — Flexible subject/topic tags
@@ -19,20 +19,24 @@ The library stores all kinds of written works in a normalized schema with:
 
 All core fields use `NOT NULL` constraints. This means an ingestion agent **cannot** store a work without generating:
 
-- A **summary** (>50 chars) — used for semantic embedding
+- A **summary** (>50 chars) — primary body of the semantic embedding
 - **Insights** (>20 chars) — key takeaways and relevance notes
 - **Publication date**, **work type**, **language**, and **shared_by** provenance
 
 If any required field is missing, the INSERT fails with a clear error indicating what's needed. This enforces a complete ingestion workflow at the database level, not just policy.
 
-### Summary-Only Embedding
+### Embedding Content
 
-Only the `summary` field gets embedded into `memory_embeddings`. This is intentional:
+Each library work produces a single embedding in `memory_embeddings`. The embedded text includes:
 
-- One high-density embedding per work (not dozens of fragmented chunks)
-- Summaries are written to maximize semantic searchability
-- On recall hit, the full record (abstract, content, insights) is fetched from the database
-- Reduces embedding token cost and improves search precision
+- **Title** — with edition when present
+- **Authors** — in original order, or "Unknown" if none recorded
+- **Work type and publication date**
+- **Summary** — the primary semantic content (200-400 words)
+- **Notable quotes** — if present, appended as `Notable quotes: ...` (improves recall for quoted passages)
+- **Tags** — if any tags are linked via `library_work_tags`, appended as `Topics: tag1, tag2, ...` (alphabetically ordered)
+
+This approach gives one high-density embedding per work rather than chunking full text. On a recall hit, the full record (abstract, content, insights) is fetched from the database. Tags and notable quotes are included so semantic search can match on topic keywords and key phrases.
 
 ## Tables
 
@@ -45,7 +49,7 @@ Only the `summary` field gets embedded into `memory_embeddings`. This is intenti
 | work_type | TEXT | ✅ | paper, book, novel, poem, short_story, essay, article, blog_post, whitepaper, report, thesis, dissertation, magazine, newsletter, speech, other |
 | publication_date | DATE | ✅ | Date of publication |
 | language | TEXT | ✅ | ISO language code (default: 'en') |
-| summary | TEXT | ✅ | Concise semantic summary (200-400 words). Generated during ingestion. Used for embedding. |
+| summary | TEXT | ✅ | Concise semantic summary (200-400 words). Generated during ingestion. Primary body of the semantic embedding. |
 | url | TEXT | | Link to the work |
 | doi | TEXT | | Digital Object Identifier |
 | arxiv_id | TEXT | | arXiv identifier |
@@ -142,7 +146,9 @@ Only works where `embed = true` are included in the semantic embedding pipeline.
 ```sql
 -- Fetch works to embed (respects the embed flag)
 SELECT w.id,
-    w.title || ' by ' ||
+    w.title ||
+    COALESCE(' (' || w.edition || ')', '') ||
+    ' by ' ||
     COALESCE((
         SELECT string_agg(a.name, ', ' ORDER BY wa.author_order)
         FROM library_authors a
@@ -150,7 +156,14 @@ SELECT w.id,
         WHERE wa.work_id = w.id
     ), 'Unknown') ||
     ' (' || w.work_type || ', ' || w.publication_date || '). ' ||
-    w.summary
+    w.summary ||
+    COALESCE(' Notable quotes: ' || array_to_string(w.notable_quotes, ' | '), '') ||
+    COALESCE(' Topics: ' || (
+        SELECT string_agg(t.name, ', ' ORDER BY t.name)
+        FROM library_tags t
+        JOIN library_work_tags wt ON t.id = wt.tag_id
+        WHERE wt.work_id = w.id
+    ), '')
 FROM library_works w
 WHERE w.embed = true
 ```

--- a/scripts/embed-full-database.py
+++ b/scripts/embed-full-database.py
@@ -63,7 +63,9 @@ TABLES_TO_EMBED = {
     """,
     "library": """
         SELECT w.id,
-            w.title || ' by ' ||
+            w.title ||
+            COALESCE(' (' || w.edition || ')', '') ||
+            ' by ' ||
             COALESCE((
                 SELECT string_agg(a.name, ', ' ORDER BY wa.author_order)
                 FROM library_authors a
@@ -72,8 +74,15 @@ TABLES_TO_EMBED = {
             ), 'Unknown') ||
             ' (' || w.work_type || ', ' || w.publication_date || '). ' ||
             w.summary ||
-            COALESCE(' Notable quotes: ' || array_to_string(w.notable_quotes, ' | '), '')
+            COALESCE(' Notable quotes: ' || array_to_string(w.notable_quotes, ' | '), '') ||
+            COALESCE(' Topics: ' || (
+                SELECT string_agg(t.name, ', ' ORDER BY t.name)
+                FROM library_tags t
+                JOIN library_work_tags wt ON t.id = wt.tag_id
+                WHERE wt.work_id = w.id
+            ), '')
         FROM library_works w
+        WHERE w.embed = true
     """,
 }
 

--- a/scripts/embed-library.py
+++ b/scripts/embed-library.py
@@ -37,7 +37,13 @@ LIBRARY_QUERY = """
         ), 'Unknown') ||
         ' (' || w.work_type || ', ' || w.publication_date || '). ' ||
         w.summary ||
-        COALESCE(' Notable quotes: ' || array_to_string(w.notable_quotes, ' | '), '')
+        COALESCE(' Notable quotes: ' || array_to_string(w.notable_quotes, ' | '), '') ||
+        COALESCE(' Topics: ' || (
+            SELECT string_agg(t.name, ', ' ORDER BY t.name)
+            FROM library_tags t
+            JOIN library_work_tags wt ON t.id = wt.tag_id
+            WHERE wt.work_id = w.id
+        ), '')
     FROM library_works w
     WHERE w.embed = true
 """

--- a/scripts/embed-library.py
+++ b/scripts/embed-library.py
@@ -10,7 +10,7 @@ Usage:
 Requires:
     - OPENAI_API_KEY environment variable
     - PostgreSQL with pgvector extension
-    - library_works, library_authors, library_work_authors tables
+    - library_works, library_authors, library_work_authors, library_tags, library_work_tags tables
 """
 
 import os


### PR DESCRIPTION
## Summary
Added a correlated subquery to LIBRARY_QUERY in embed-library.py that joins library_work_tags → library_tags and appends topic tags to embedding content. Tags are alphabetically ordered for deterministic embeddings. Works with no tags produce no trailing text.

## Changes
- Modified `scripts/embed-library.py` (LIBRARY_QUERY)
- Updated docs (`docs/library-schema.md`, `docs/database-schema-guide.md`, `CHANGELOG.md`)
- Synced `scripts/embed-full-database.py` library query

## Testing
All 8 test cases passed (happy path, zero tags, single tag, truncation, reindex, deterministic ordering, embedding influence, special characters)

## Reference
Fixes #159