### PR TITLE
feat: prioritize tags over quotes in embedding text and cap summary

### DIFF
--- a/scripts/embed-library.py
+++ b/scripts/embed-library.py
@@ -36,14 +36,14 @@ LIBRARY_QUERY = """
             WHERE wa.work_id = w.id
         ), 'Unknown') ||
         ' (' || w.work_type || ', ' || w.publication_date || '). ' ||
-        w.summary ||
-        COALESCE(' Notable quotes: ' || array_to_string(w.notable_quotes, ' | '), '') ||
+        left(w.summary, 1200) ||
         COALESCE(' Topics: ' || (
             SELECT string_agg(t.name, ', ' ORDER BY t.name)
             FROM library_tags t
             JOIN library_work_tags wt ON t.id = wt.tag_id
             WHERE wt.work_id = w.id
-        ), '')
+        ), '') ||
+        COALESCE(' Notable quotes: ' || array_to_string(w.notable_quotes, ' | '), '')
     FROM library_works w
     WHERE w.embed = true
 """


### PR DESCRIPTION
Reorders LIBRARY_QUERY to place Topics before Notable quotes, and caps summary at 1200 chars. Ensures topic tags always make it into embeddings. Fixes #162